### PR TITLE
feat: add keyboard controls, mouse tracking, and configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,50 @@
 
 https://github.com/user-attachments/assets/23e9aeac-4f60-47e6-9c49-7a3706bcdbe9
 
-Scroll with your mouse to zoom and use left mouse click and drag to move the
-viewport.
+A powerful and customizable screen magnifier for Wayland compositors with mouse and keyboard controls.
 
-Use right click to exit.
+## Usage
+
+```sh
+wooz [options...]
+```
+
+### Options
+
+* `-h, --help` - Show help message and quit
+* `--map-close KEY` - Set key to close (e.g., 'Esc', 'q', 'x')
+* `--mouse-track` - Enable mouse tracking (follow mouse without clicking)
+* `--zoom-in PERCENT` - Set initial zoom percentage (e.g., '10%', '50%')
+
+### Controls
+
+**Mouse:**
+* Scroll wheel - Zoom in/out at mouse position
+* Left click + drag - Pan the view
+* Right click - Exit
+* Double click - Restore/unzoom to original view
+
+**Keyboard:**
+* `+` / `-` - Zoom in/out at screen center
+* Arrow keys - Pan the view
+* `0` - Restore/unzoom to original view
+* `Esc` - Exit (default, customizable with `--map-close`)
+
+### Examples
+
+```sh
+# Start with 10% zoom at center
+wooz --zoom-in 10%
+
+# Enable mouse tracking (viewport follows mouse)
+wooz --mouse-track
+
+# Use 'q' key to exit instead of Esc
+wooz --map-close q
+
+# Combine options
+wooz --zoom-in 25% --mouse-track --map-close x
+```
 
 
 ## Building from source

--- a/include/wooz.h
+++ b/include/wooz.h
@@ -101,6 +101,7 @@ struct wooz_window {
   bool is_tiled_left;
   bool is_tiled_right;
   bool is_tiled; /* At least one of is_tiled_{top,bottom,left,right} is true */
+  bool initial_zoom_applied;
   struct {
     int width;
     int height;

--- a/include/wooz.h
+++ b/include/wooz.h
@@ -1,9 +1,18 @@
 #ifndef _WOOZ_H
 #define _WOOZ_H
 
+#include <stdbool.h>
+#include <stdint.h>
+#include <time.h>
 #include <wayland-client.h>
 
 #include "box.h"
+
+struct wooz_config {
+  uint32_t close_key; // Linux input event code for close action (0 = default Esc)
+  bool mouse_track;   // Enable mouse tracking
+  double initial_zoom; // Initial zoom percentage (0.0 = no zoom, 0.1 = 10%)
+};
 
 struct wooz_state {
   struct wl_compositor *compositor;
@@ -16,10 +25,17 @@ struct wooz_state {
   struct wp_viewporter *viewporter;
   struct wl_seat *seat;
   struct wl_pointer *pointer;
+  struct wl_keyboard *keyboard;
   struct wl_list outputs;
   struct wl_list windows;
 
   struct wooz_window *focused;
+  struct wooz_config config;
+
+  // Key repeat state
+  uint32_t pressed_key;
+  timer_t repeat_timer;
+  bool repeat_timer_created;
 
   size_t n_done;
 };
@@ -58,11 +74,16 @@ struct wooz_window {
 
   // Viewport source rectangle.
   struct wooz_boxf view_source;
+  struct wooz_boxf initial_view_source; // For restore/unzoom
 
   // Mouse pointer position if window is focused.
   double pointer_x;
   double pointer_y;
   bool pointer_pressed;
+
+  // Double-click detection
+  uint32_t last_click_time;
+  uint32_t last_click_button;
 
   struct {
     bool maximize : 1;

--- a/include/wooz.h
+++ b/include/wooz.h
@@ -34,8 +34,7 @@ struct wooz_state {
 
   // Key repeat state
   uint32_t pressed_key;
-  timer_t repeat_timer;
-  bool repeat_timer_created;
+  int repeat_timer_fd;
 
   size_t n_done;
 };


### PR DESCRIPTION
## Usage

Implement comprehensive keyboard support with timer-based key repeat for
zoom (+/-) and pan (arrow keys). Add double-click to restore view and
0 key to unzoom. Support command-line options: --zoom-in for initial
zoom percentage, --mouse-track for viewport following mouse cursor,
and --map-close for customizable exit key.

```sh
wooz [options...]
```

### Options

* `-h, --help` - Show help message and quit
* `--map-close KEY` - Set key to close (e.g., 'Esc', 'q', 'x')
* `--mouse-track` - Enable mouse tracking (follow mouse without clicking)
* `--zoom-in PERCENT` - Set initial zoom percentage (e.g., '10%', '50%')

### Controls

**Mouse:**
* Scroll wheel - Zoom in/out at mouse position
* Left click + drag - Pan the view
* Right click - Exit
* Double click - Restore/unzoom to original view

**Keyboard:**
* `+` / `-` - Zoom in/out at screen center
* Arrow keys - Pan the view
* `0` - Restore/unzoom to original view
* `Esc` - Exit (default, customizable with `--map-close`)

### Examples

```sh
# Start with 10% zoom at center
wooz --zoom-in 10%

# Enable mouse tracking (viewport follows mouse)
wooz --mouse-track

# Use 'q' key to exit instead of Esc
wooz --map-close q

# Combine options
wooz --zoom-in 25% --mouse-track --map-close x
```