### PR TITLE
feat: add --invert-scroll option to reverse scroll direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ wooz [options...]
 * `--map-close KEY` - Set key to close (e.g., 'Esc', 'q', 'x')
 * `--mouse-track` - Enable mouse tracking (follow mouse without clicking)
 * `--zoom-in PERCENT` - Set initial zoom percentage (e.g., '10%', '50%')
+* `--invert-scroll` - Invert scroll direction (scroll up zooms in)
 
 ### Controls
 
@@ -45,6 +46,9 @@ wooz --map-close q
 
 # Combine options
 wooz --zoom-in 25% --mouse-track --map-close x
+
+# Invert scroll direction (scroll up to zoom in)
+wooz --invert-scroll
 ```
 
 

--- a/include/wooz.h
+++ b/include/wooz.h
@@ -12,6 +12,7 @@ struct wooz_config {
   uint32_t close_key; // Linux input event code for close action (0 = default Esc)
   bool mouse_track;   // Enable mouse tracking
   double initial_zoom; // Initial zoom percentage (0.0 = no zoom, 0.1 = 10%)
+  bool invert_scroll; // Invert scroll direction (scroll up zooms in)
 };
 
 struct wooz_state {

--- a/main.c
+++ b/main.c
@@ -588,6 +588,11 @@ static void pointer_handle_axis(void *data, struct wl_pointer *pointer,
   // x10 for faster zoom.
   double scroll = wl_fixed_to_double(value) * scale * 10;
 
+  // Invert scroll if configured
+  if (state->config.invert_scroll) {
+    scroll = -scroll;
+  }
+
   if (axis == WL_POINTER_AXIS_VERTICAL_SCROLL) {
     apply_zoom(win, scroll, win->pointer_x, win->pointer_y);
     render_window(win);
@@ -782,6 +787,7 @@ static const char usage[] =
     "  --map-close KEY         Set key to close (e.g., 'Esc', 'q')\n"
     "  --mouse-track           Enable mouse tracking (follow mouse without clicking)\n"
     "  --zoom-in PERCENT       Set initial zoom percentage (e.g., '10%', '50%')\n"
+    "  --invert-scroll         Invert scroll direction (scroll up zooms in)\n"
     "\n"
     "Controls:\n"
     "  Mouse scroll            Zoom in/out at mouse position\n"
@@ -812,6 +818,7 @@ int main(int argc, char *argv[]) {
       {"map-close", required_argument, 0, 'c'},
       {"mouse-track", no_argument, 0, 'm'},
       {"zoom-in", required_argument, 0, 'z'},
+      {"invert-scroll", no_argument, 0, 'i'},
       {0, 0, 0, 0}
   };
 
@@ -847,6 +854,9 @@ int main(int argc, char *argv[]) {
       }
       break;
     }
+    case 'i':
+      config.invert_scroll = true;
+      break;
     default:
       fprintf(stderr, "%s", usage);
       return EXIT_FAILURE;


### PR DESCRIPTION
Add new command-line option to invert the scroll behavior, allowing users to scroll up to zoom in and scroll down to zoom out instead of the default behavior.

Related #4 