### PR TITLE
feat: add --output option to run on specific display

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ wooz [options...]
 * `-h, --help` - Show help message and quit
 * `--map-close KEY` - Set key to close (e.g., 'Esc', 'q', 'x')
 * `--mouse-track` - Enable mouse tracking (follow mouse without clicking)
+* `--output NAME` - Run on specific output (e.g., 'DP-1', 'HDMI-A-1')
 * `--zoom-in PERCENT` - Set initial zoom percentage (e.g., '10%', '50%')
 
 ### Controls
@@ -43,8 +44,11 @@ wooz --mouse-track
 # Use 'q' key to exit instead of Esc
 wooz --map-close q
 
+# Run on a specific output only
+wooz --output DP-1
+
 # Combine options
-wooz --zoom-in 25% --mouse-track --map-close x
+wooz --zoom-in 25% --mouse-track --map-close x --output HDMI-A-1
 ```
 
 

--- a/include/wooz.h
+++ b/include/wooz.h
@@ -12,6 +12,7 @@ struct wooz_config {
   uint32_t close_key; // Linux input event code for close action (0 = default Esc)
   bool mouse_track;   // Enable mouse tracking
   double initial_zoom; // Initial zoom percentage (0.0 = no zoom, 0.1 = 10%)
+  char *output_filter; // Filter to specific output name (NULL = all outputs)
 };
 
 struct wooz_state {


### PR DESCRIPTION
I am using wooz for my classes and I usually share only one screen with the students, so made it possible to filter a single output.

Add support for filtering to a single output using the --output option. When specified, wooz will only magnify the named output instead of all connected displays. Without this option, the existing behavior of magnifying all outputs is preserved.

`wooz --output "DP-1"`  to zoom only my screenshare monitor.