### PR TITLE
Use wlr-layer-shell overlay instead of xdg-shell fullscreen

### DIFF
--- a/include/wooz.h
+++ b/include/wooz.h
@@ -18,7 +18,7 @@ struct wooz_config {
 
 struct wooz_state {
   struct wl_compositor *compositor;
-  struct xdg_wm_base *shell;
+  struct zwlr_layer_shell_v1 *layer_shell;
   struct wl_display *display;
   struct wl_registry *registry;
   struct wl_shm *shm;
@@ -68,8 +68,7 @@ struct wooz_window {
   struct wooz_output *output;
   struct wl_list link;
 
-  struct xdg_toplevel *xdg_toplevel;
-  struct xdg_surface *xdg_surface;
+  struct zwlr_layer_surface_v1 *layer_surface;
   struct wp_viewport *viewport;
   struct wl_surface *surface;
 
@@ -86,36 +85,9 @@ struct wooz_window {
   uint32_t last_click_time;
   uint32_t last_click_button;
 
-  struct {
-    bool maximize : 1;
-    bool minimize : 1;
-    bool window_menu : 1;
-    bool fullscreen : 1;
-  } wm_capabilities;
-
   bool is_focused;
   bool is_configured;
-  bool is_fullscreen;
-  bool is_maximized;
-  bool is_resizing;
-  bool is_tiled_top;
-  bool is_tiled_bottom;
-  bool is_tiled_left;
-  bool is_tiled_right;
-  bool is_tiled; /* At least one of is_tiled_{top,bottom,left,right} is true */
   bool initial_zoom_applied;
-  struct {
-    int width;
-    int height;
-    bool is_activated : 1;
-    bool is_fullscreen : 1;
-    bool is_maximized : 1;
-    bool is_resizing : 1;
-    bool is_tiled_top : 1;
-    bool is_tiled_bottom : 1;
-    bool is_tiled_left : 1;
-    bool is_tiled_right : 1;
-  } configure;
 };
 
 #endif

--- a/main.c
+++ b/main.c
@@ -15,7 +15,7 @@
 #include "viewporter-protocol.h"
 #include "wlr-screencopy-unstable-v1-protocol.h"
 #include "xdg-output-unstable-v1-protocol.h"
-#include "xdg-shell-protocol.h"
+#include "wlr-layer-shell-unstable-v1-protocol.h"
 
 // Key codes from linux/input-event-codes.h
 #define KEY_ESC 1
@@ -309,41 +309,23 @@ static const struct wl_output_listener output_listener = {
     .scale = output_handle_scale,
 };
 
-static void xdg_wm_base_ping(void *data, struct xdg_wm_base *shell,
-                             uint32_t serial) {
-  xdg_wm_base_pong(shell, serial);
-}
-
-static const struct xdg_wm_base_listener xdg_wm_base_listener = {
-    .ping = &xdg_wm_base_ping,
-};
-
-static void xdg_surface_configure(void *data, struct xdg_surface *xdg_surface,
-                                  uint32_t serial) {
+static void layer_surface_configure(void *data,
+                                    struct zwlr_layer_surface_v1 *surface,
+                                    uint32_t serial,
+                                    uint32_t width, uint32_t height) {
   struct wooz_window *win = data;
 
   wl_surface_set_buffer_transform(win->surface, win->output->transform);
   win->is_configured = true;
-  win->is_maximized = win->configure.is_maximized;
-  win->is_fullscreen = win->configure.is_fullscreen;
-  win->is_resizing = win->configure.is_resizing;
-  win->is_tiled_top = win->configure.is_tiled_top;
-  win->is_tiled_bottom = win->configure.is_tiled_bottom;
-  win->is_tiled_left = win->configure.is_tiled_left;
-  win->is_tiled_right = win->configure.is_tiled_right;
-  win->is_tiled = win->is_tiled_top || win->is_tiled_bottom ||
-                  win->is_tiled_left || win->is_tiled_right;
 
-  xdg_surface_ack_configure(win->xdg_surface, serial);
+  zwlr_layer_surface_v1_ack_configure(surface, serial);
   wl_surface_attach(win->surface, win->output->buffer->wl_buffer, 0, 0);
 
-  if (win->viewport != NULL && win->configure.width != 0 &&
-      win->configure.height != 0) {
-    wp_viewport_set_destination(win->viewport, win->configure.width,
-                                win->configure.height);
+  if (win->viewport != NULL && width != 0 && height != 0) {
+    wp_viewport_set_destination(win->viewport, (int)width, (int)height);
   }
 
-  // Apply initial zoom on first configure
+  // Apply initial zoom once, on the first configure event
   if (!win->initial_zoom_applied && win->state->config.initial_zoom > 0.0) {
     double center_x = win->output->logical_geometry.width / 2.0;
     double center_y = win->output->logical_geometry.height / 2.0;
@@ -352,132 +334,21 @@ static void xdg_surface_configure(void *data, struct xdg_surface *xdg_surface,
     apply_zoom(win, zoom_pixels, center_x, center_y);
     render_window(win);
     win->initial_zoom_applied = true;
-    return; // render_window already calls wl_surface_commit
+    return;
   }
 
   wl_surface_commit(win->surface);
 }
 
-static const struct xdg_surface_listener xdg_surface_listener = {
-    .configure = &xdg_surface_configure,
-};
-
-static void xdg_toplevel_configure(void *data,
-                                   struct xdg_toplevel *xdg_toplevel,
-                                   int32_t width, int32_t height,
-                                   struct wl_array *states) {
-  bool is_activated = false;
-  bool is_fullscreen = false;
-  bool is_maximized = false;
-  bool is_resizing = false;
-  bool is_tiled_top = false;
-  bool is_tiled_bottom = false;
-  bool is_tiled_left = false;
-  bool is_tiled_right = false;
-  bool is_suspended = false;
-
-  enum xdg_toplevel_state *state;
-  wl_array_for_each(state, states) {
-    switch (*state) {
-    case XDG_TOPLEVEL_STATE_MAXIMIZED:
-      is_maximized = true;
-      break;
-    case XDG_TOPLEVEL_STATE_FULLSCREEN:
-      is_fullscreen = true;
-      break;
-    case XDG_TOPLEVEL_STATE_RESIZING:
-      is_resizing = true;
-      break;
-    case XDG_TOPLEVEL_STATE_ACTIVATED:
-      is_activated = true;
-      break;
-    case XDG_TOPLEVEL_STATE_TILED_LEFT:
-      is_tiled_left = true;
-      break;
-    case XDG_TOPLEVEL_STATE_TILED_RIGHT:
-      is_tiled_right = true;
-      break;
-    case XDG_TOPLEVEL_STATE_TILED_TOP:
-      is_tiled_top = true;
-      break;
-    case XDG_TOPLEVEL_STATE_TILED_BOTTOM:
-      is_tiled_bottom = true;
-      break;
-    case XDG_TOPLEVEL_STATE_SUSPENDED:
-      is_suspended = true;
-      break;
-    default:
-      break;
-    }
-  }
-
-  (void)is_suspended;
-
-  /*
-   * Changes done here are ignored until the configure event has
-   * been ack:ed in xdg_surface_configure().
-   *
-   * So, just store the config data and apply it later, in
-   * xdg_surface_configure() after we've ack:ed the event.
-   */
-  struct wooz_window *win = data;
-  win->configure.is_activated = is_activated;
-  win->configure.is_fullscreen = is_fullscreen;
-  win->configure.is_maximized = is_maximized;
-  win->configure.is_resizing = is_resizing;
-  win->configure.is_tiled_top = is_tiled_top;
-  win->configure.is_tiled_bottom = is_tiled_bottom;
-  win->configure.is_tiled_left = is_tiled_left;
-  win->configure.is_tiled_right = is_tiled_right;
-  win->configure.width = width;
-  win->configure.height = height;
-}
-
-static void xdg_toplevel_close(void *data, struct xdg_toplevel *xdg_toplevel) {
+static void layer_surface_closed(void *data,
+                                 struct zwlr_layer_surface_v1 *surface) {
   struct wooz_window *win = data;
   win->state->n_done = 0;
 }
 
-static void xdg_toplevel_configure_bounds(void *data,
-                                          struct xdg_toplevel *xdg_toplevel,
-                                          int32_t width, int32_t height) {
-  /* TODO: ensure we don't pick a bigger size */
-}
-
-static void xdg_toplevel_wm_capabilities(void *data,
-                                         struct xdg_toplevel *xdg_toplevel,
-                                         struct wl_array *caps) {
-  struct wooz_window *win = data;
-
-  win->wm_capabilities.maximize = false;
-  win->wm_capabilities.minimize = false;
-  win->wm_capabilities.window_menu = false;
-  win->wm_capabilities.fullscreen = false;
-
-  enum xdg_toplevel_wm_capabilities *cap;
-  wl_array_for_each(cap, caps) {
-    switch (*cap) {
-    case XDG_TOPLEVEL_WM_CAPABILITIES_MAXIMIZE:
-      win->wm_capabilities.maximize = true;
-      break;
-    case XDG_TOPLEVEL_WM_CAPABILITIES_MINIMIZE:
-      win->wm_capabilities.minimize = true;
-      break;
-    case XDG_TOPLEVEL_WM_CAPABILITIES_WINDOW_MENU:
-      win->wm_capabilities.window_menu = true;
-      break;
-    case XDG_TOPLEVEL_WM_CAPABILITIES_FULLSCREEN:
-      win->wm_capabilities.fullscreen = true;
-      break;
-    }
-  }
-}
-
-static const struct xdg_toplevel_listener xdg_toplevel_listener = {
-    .configure = &xdg_toplevel_configure,
-    .close = &xdg_toplevel_close,
-    .configure_bounds = &xdg_toplevel_configure_bounds,
-    .wm_capabilities = xdg_toplevel_wm_capabilities,
+static const struct zwlr_layer_surface_v1_listener layer_surface_listener = {
+    .configure = &layer_surface_configure,
+    .closed = &layer_surface_closed,
 };
 
 static void pointer_handle_enter(void *data, struct wl_pointer *pointer,
@@ -757,9 +628,9 @@ static void handle_global(void *data, struct wl_registry *registry,
              0) {
     state->screencopy_manager = wl_registry_bind(
         registry, name, &zwlr_screencopy_manager_v1_interface, 1);
-  } else if (strcmp(interface, xdg_wm_base_interface.name) == 0) {
-    state->shell = wl_registry_bind(registry, name, &xdg_wm_base_interface, 1);
-    xdg_wm_base_add_listener(state->shell, &xdg_wm_base_listener, state);
+  } else if (strcmp(interface, zwlr_layer_shell_v1_interface.name) == 0) {
+    state->layer_shell = wl_registry_bind(registry, name,
+                                          &zwlr_layer_shell_v1_interface, 4);
   } else if (strcmp(interface, wp_viewporter_interface.name) == 0) {
     state->viewporter =
         wl_registry_bind(registry, name, &wp_viewporter_interface, 1);
@@ -911,8 +782,8 @@ int main(int argc, char *argv[]) {
     fprintf(stderr, "wl_compositor is missing\n");
     return EXIT_FAILURE;
   }
-  if (state.shell == NULL) {
-    fprintf(stderr, "no XDG shell interface\n");
+  if (state.layer_shell == NULL) {
+    fprintf(stderr, "compositor doesn't support wlr-layer-shell\n");
     return EXIT_FAILURE;
   }
   if (state.shm == NULL) {
@@ -1020,13 +891,19 @@ int main(int argc, char *argv[]) {
       return EXIT_FAILURE;
     }
 
-    win->xdg_surface = xdg_wm_base_get_xdg_surface(state.shell, win->surface);
-    xdg_surface_add_listener(win->xdg_surface, &xdg_surface_listener, win);
-    win->xdg_toplevel = xdg_surface_get_toplevel(win->xdg_surface);
-    xdg_toplevel_add_listener(win->xdg_toplevel, &xdg_toplevel_listener, win);
-    xdg_toplevel_set_app_id(win->xdg_toplevel, "dev.negrel.wooz");
-    xdg_toplevel_set_title(win->xdg_toplevel, "wooz");
-    xdg_toplevel_set_fullscreen(win->xdg_toplevel, output->wl_output);
+    win->layer_surface = zwlr_layer_shell_v1_get_layer_surface(
+        state.layer_shell, win->surface, output->wl_output,
+        ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY, "wooz");
+    zwlr_layer_surface_v1_set_anchor(win->layer_surface,
+        ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP |
+        ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM |
+        ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT |
+        ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT);
+    zwlr_layer_surface_v1_set_keyboard_interactivity(win->layer_surface,
+        ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE);
+    zwlr_layer_surface_v1_set_exclusive_zone(win->layer_surface, -1);
+    zwlr_layer_surface_v1_add_listener(win->layer_surface,
+        &layer_surface_listener, win);
 
     wl_surface_commit(win->surface);
   }
@@ -1088,10 +965,8 @@ int main(int argc, char *argv[]) {
 
     // Free window.
     wl_list_remove(&win->link);
-    if (win->xdg_toplevel != NULL)
-      xdg_toplevel_destroy(win->xdg_toplevel);
-    if (win->xdg_surface != NULL)
-      xdg_surface_destroy(win->xdg_surface);
+    if (win->layer_surface != NULL)
+      zwlr_layer_surface_v1_destroy(win->layer_surface);
     if (win->viewport != NULL)
       wp_viewport_destroy(win->viewport);
     if (win->surface != NULL)
@@ -1123,7 +998,7 @@ int main(int argc, char *argv[]) {
     wl_keyboard_release(state.keyboard);
   }
   wl_seat_release(state.seat);
-  xdg_wm_base_destroy(state.shell);
+  zwlr_layer_shell_v1_destroy(state.layer_shell);
   wp_viewporter_destroy(state.viewporter);
   wl_shm_destroy(state.shm);
   wl_registry_destroy(state.registry);

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -23,6 +23,7 @@ protocols = [
 	wl_protocol_dir / 'staging/fractional-scale/fractional-scale-v1.xml',
 	wl_protocol_dir / 'stable/viewporter/viewporter.xml',
 	'wlr-screencopy-unstable-v1.xml',
+	'wlr-layer-shell-unstable-v1.xml',
 ]
 
 protocols_src = []

--- a/protocol/wlr-layer-shell-unstable-v1.xml
+++ b/protocol/wlr-layer-shell-unstable-v1.xml
@@ -1,0 +1,407 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_layer_shell_unstable_v1">
+  <copyright>
+    Copyright © 2017 Drew DeVault
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <interface name="zwlr_layer_shell_v1" version="5">
+    <description summary="create surfaces that are layers of the desktop">
+      Clients can use this interface to assign the surface_layer role to
+      wl_surfaces. Such surfaces are assigned to a "layer" of the output and
+      rendered with a defined z-depth respective to each other. They may also be
+      anchored to the edges and corners of a screen and specify input handling
+      semantics. This interface should be suitable for the implementation of
+      many desktop shell components, and a broad number of other applications
+      that interact with the desktop.
+    </description>
+
+    <request name="get_layer_surface">
+      <description summary="create a layer_surface from a surface">
+        Create a layer surface for an existing surface. This assigns the role of
+        layer_surface, or raises a protocol error if another role is already
+        assigned.
+
+        Creating a layer surface from a wl_surface which has a buffer attached
+        or committed is a client error, and any attempts by a client to attach
+        or manipulate a buffer prior to the first layer_surface.configure call
+        must also be treated as errors.
+
+        After creating a layer_surface object and setting it up, the client
+        must perform an initial commit without any buffer attached.
+        The compositor will reply with a layer_surface.configure event.
+        The client must acknowledge it and is then allowed to attach a buffer
+        to map the surface.
+
+        You may pass NULL for output to allow the compositor to decide which
+        output to use. Generally this will be the one that the user most
+        recently interacted with.
+
+        Clients can specify a namespace that defines the purpose of the layer
+        surface.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_layer_surface_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+      <arg name="layer" type="uint" enum="layer" summary="layer to add this surface to"/>
+      <arg name="namespace" type="string" summary="namespace for the layer surface"/>
+    </request>
+
+    <enum name="error">
+      <entry name="role" value="0" summary="wl_surface has another role"/>
+      <entry name="invalid_layer" value="1" summary="layer value is invalid"/>
+      <entry name="already_constructed" value="2" summary="wl_surface has a buffer attached or committed"/>
+    </enum>
+
+    <enum name="layer">
+      <description summary="available layers for surfaces">
+        These values indicate which layers a surface can be rendered in. They
+        are ordered by z depth, bottom-most first. Traditional shell surfaces
+        will typically be rendered between the bottom and top layers.
+        Fullscreen shell surfaces are typically rendered at the top layer.
+        Multiple surfaces can share a single layer, and ordering within a
+        single layer is undefined.
+      </description>
+
+      <entry name="background" value="0"/>
+      <entry name="bottom" value="1"/>
+      <entry name="top" value="2"/>
+      <entry name="overlay" value="3"/>
+    </enum>
+
+    <!-- Version 3 additions -->
+
+    <request name="destroy" type="destructor" since="3">
+      <description summary="destroy the layer_shell object">
+        This request indicates that the client will not use the layer_shell
+        object any more. Objects that have been created through this instance
+        are not affected.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_layer_surface_v1" version="5">
+    <description summary="layer metadata interface">
+      An interface that may be implemented by a wl_surface, for surfaces that
+      are designed to be rendered as a layer of a stacked desktop-like
+      environment.
+
+      Layer surface state (layer, size, anchor, exclusive zone,
+      margin, interactivity) is double-buffered, and will be applied at the
+      time wl_surface.commit of the corresponding wl_surface is called.
+
+      Attaching a null buffer to a layer surface unmaps it.
+
+      Unmapping a layer_surface means that the surface cannot be shown by the
+      compositor until it is explicitly mapped again. The layer_surface
+      returns to the state it had right after layer_shell.get_layer_surface.
+      The client can re-map the surface by performing a commit without any
+      buffer attached, waiting for a configure event and handling it as usual.
+    </description>
+
+    <request name="set_size">
+      <description summary="sets the size of the surface">
+        Sets the size of the surface in surface-local coordinates. The
+        compositor will display the surface centered with respect to its
+        anchors.
+
+        If you pass 0 for either value, the compositor will assign it and
+        inform you of the assignment in the configure event. You must set your
+        anchor to opposite edges in the dimensions you omit; not doing so is a
+        protocol error. Both values are 0 by default.
+
+        Size is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="width" type="uint"/>
+      <arg name="height" type="uint"/>
+    </request>
+
+    <request name="set_anchor">
+      <description summary="configures the anchor point of the surface">
+        Requests that the compositor anchor the surface to the specified edges
+        and corners. If two orthogonal edges are specified (e.g. 'top' and
+        'left'), then the anchor point will be the intersection of the edges
+        (e.g. the top left corner of the output); otherwise the anchor point
+        will be centered on that edge, or in the center if none is specified.
+
+        Anchor is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="anchor" type="uint" enum="anchor"/>
+    </request>
+
+    <request name="set_exclusive_zone">
+      <description summary="configures the exclusive geometry of this surface">
+        Requests that the compositor avoids occluding an area with other
+        surfaces. The compositor's use of this information is
+        implementation-dependent - do not assume that this region will not
+        actually be occluded.
+
+        A positive value is only meaningful if the surface is anchored to one
+        edge or an edge and both perpendicular edges. If the surface is not
+        anchored, anchored to only two perpendicular edges (a corner), anchored
+        to only two parallel edges or anchored to all edges, a positive value
+        will be treated the same as zero.
+
+        A positive zone is the distance from the edge in surface-local
+        coordinates to consider exclusive.
+
+        Surfaces that do not wish to have an exclusive zone may instead specify
+        how they should interact with surfaces that do. If set to zero, the
+        surface indicates that it would like to be moved to avoid occluding
+        surfaces with a positive exclusive zone. If set to -1, the surface
+        indicates that it would not like to be moved to accommodate for other
+        surfaces, and the compositor should extend it all the way to the edges
+        it is anchored to.
+
+        For example, a panel might set its exclusive zone to 10, so that
+        maximized shell surfaces are not shown on top of it. A notification
+        might set its exclusive zone to 0, so that it is moved to avoid
+        occluding the panel, but shell surfaces are shown underneath it. A
+        wallpaper or lock screen might set their exclusive zone to -1, so that
+        they stretch below or over the panel.
+
+        The default value is 0.
+
+        Exclusive zone is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="zone" type="int"/>
+    </request>
+
+    <request name="set_margin">
+      <description summary="sets a margin from the anchor point">
+        Requests that the surface be placed some distance away from the anchor
+        point on the output, in surface-local coordinates. Setting this value
+        for edges you are not anchored to has no effect.
+
+        The exclusive zone includes the margin.
+
+        Margin is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="top" type="int"/>
+      <arg name="right" type="int"/>
+      <arg name="bottom" type="int"/>
+      <arg name="left" type="int"/>
+    </request>
+
+    <enum name="keyboard_interactivity">
+      <description summary="types of keyboard interaction possible for a layer shell surface">
+        Types of keyboard interaction possible for layer shell surfaces. The
+        rationale for this is twofold: (1) some applications are not interested
+        in keyboard events and not allowing them to be focused can improve the
+        desktop experience; (2) some applications will want to take exclusive
+        keyboard focus.
+      </description>
+
+      <entry name="none" value="0">
+        <description summary="no keyboard focus is possible">
+          This value indicates that this surface is not interested in keyboard
+          events and the compositor should never assign it the keyboard focus.
+
+          This is the default value, set for newly created layer shell surfaces.
+
+          This is useful for e.g. desktop widgets that display information or
+          only have interaction with non-keyboard input devices.
+        </description>
+      </entry>
+      <entry name="exclusive" value="1">
+        <description summary="request exclusive keyboard focus">
+          Request exclusive keyboard focus if this surface is above the shell surface layer.
+
+          For the top and overlay layers, the seat will always give
+          exclusive keyboard focus to the top-most layer which has keyboard
+          interactivity set to exclusive. If this layer contains multiple
+          surfaces with keyboard interactivity set to exclusive, the compositor
+          determines the one receiving keyboard events in an implementation-
+          defined manner. In this case, no guarantee is made when this surface
+          will receive keyboard focus (if ever).
+
+          For the bottom and background layers, the compositor is allowed to use
+          normal focus semantics.
+
+          This setting is mainly intended for applications that need to ensure
+          they receive all keyboard events, such as a lock screen or a password
+          prompt.
+        </description>
+      </entry>
+      <entry name="on_demand" value="2" since="4">
+        <description summary="request regular keyboard focus semantics">
+          This requests the compositor to allow this surface to be focused and
+          unfocused by the user in an implementation-defined manner. The user
+          should be able to unfocus this surface even regardless of the layer
+          it is on.
+
+          Typically, the compositor will want to use its normal mechanism to
+          manage keyboard focus between layer shell surfaces with this setting
+          and regular toplevels on the desktop layer (e.g. click to focus).
+          Nevertheless, it is possible for a compositor to require a special
+          interaction to focus or unfocus layer shell surfaces (e.g. requiring
+          a click even if focus follows the mouse normally, or providing a
+          keybinding to switch focus between layers).
+
+          This setting is mainly intended for desktop shell components (e.g.
+          panels) that allow keyboard interaction. Using this option can allow
+          implementing a desktop shell that can be fully usable without the
+          mouse.
+        </description>
+      </entry>
+    </enum>
+
+    <request name="set_keyboard_interactivity">
+      <description summary="requests keyboard events">
+        Set how keyboard events are delivered to this surface. By default,
+        layer shell surfaces do not receive keyboard events; this request can
+        be used to change this.
+
+        This setting is inherited by child surfaces set by the get_popup
+        request.
+
+        Layer surfaces receive pointer, touch, and tablet events normally. If
+        you do not want to receive them, set the input region on your surface
+        to an empty region.
+
+        Keyboard interactivity is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="keyboard_interactivity" type="uint" enum="keyboard_interactivity"/>
+    </request>
+
+    <request name="get_popup">
+      <description summary="assign this layer_surface as an xdg_popup parent">
+        This assigns an xdg_popup's parent to this layer_surface.  This popup
+        should have been created via xdg_surface::get_popup with the parent set
+        to NULL, and this request must be invoked before committing the popup's
+        initial state.
+
+        See the documentation of xdg_popup for more details about what an
+        xdg_popup is and how it is used.
+      </description>
+      <arg name="popup" type="object" interface="xdg_popup"/>
+    </request>
+
+    <request name="ack_configure">
+      <description summary="ack a configure event">
+        When a configure event is received, if a client commits the
+        surface in response to the configure event, then the client
+        must make an ack_configure request sometime before the commit
+        request, passing along the serial of the configure event.
+
+        If the client receives multiple configure events before it
+        can respond to one, it only has to ack the last configure event.
+
+        A client is not required to commit immediately after sending
+        an ack_configure request - it may even ack_configure several times
+        before its next surface commit.
+
+        A client may send multiple ack_configure requests before committing, but
+        only the last request sent before a commit indicates which configure
+        event the client really is responding to.
+      </description>
+      <arg name="serial" type="uint" summary="the serial from the configure event"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the layer_surface">
+        This request destroys the layer surface.
+      </description>
+    </request>
+
+    <event name="configure">
+      <description summary="suggest a surface change">
+        The configure event asks the client to resize its surface.
+
+        Clients should arrange their surface for the new states, and then send
+        an ack_configure request with the serial sent in this configure event at
+        some point before committing the new surface.
+
+        The client is free to dismiss all but the last configure event it
+        received.
+
+        The width and height arguments specify the size of the window in
+        surface-local coordinates.
+
+        The size is a hint, in the sense that the client is free to ignore it if
+        it doesn't resize, pick a smaller size (to satisfy aspect ratio or
+        resize in steps of NxM pixels). If the client picks a smaller size and
+        is anchored to two opposite anchors (e.g. 'top' and 'bottom'), the
+        surface will be centered on this axis.
+
+        If the width or height arguments are zero, it means the client should
+        decide its own window dimension.
+      </description>
+      <arg name="serial" type="uint"/>
+      <arg name="width" type="uint"/>
+      <arg name="height" type="uint"/>
+    </event>
+
+    <event name="closed">
+      <description summary="surface should be closed">
+        The closed event is sent by the compositor when the surface will no
+        longer be shown. The output may have been destroyed or the user may
+        have asked for it to be removed. Further changes to the surface will be
+        ignored. The client should destroy the resource after receiving this
+        event, and create a new surface if they so choose.
+      </description>
+    </event>
+
+    <enum name="error">
+      <entry name="invalid_surface_state" value="0" summary="provided surface state is invalid"/>
+      <entry name="invalid_size" value="1" summary="size is invalid"/>
+      <entry name="invalid_anchor" value="2" summary="anchor bitfield is invalid"/>
+      <entry name="invalid_keyboard_interactivity" value="3" summary="keyboard interactivity is invalid"/>
+      <entry name="invalid_exclusive_edge" value="4" summary="exclusive edge is invalid given the surface anchors"/>
+    </enum>
+
+    <enum name="anchor" bitfield="true">
+      <entry name="top" value="1" summary="the top edge of the anchor rectangle"/>
+      <entry name="bottom" value="2" summary="the bottom edge of the anchor rectangle"/>
+      <entry name="left" value="4" summary="the left edge of the anchor rectangle"/>
+      <entry name="right" value="8" summary="the right edge of the anchor rectangle"/>
+    </enum>
+
+    <!-- Version 2 additions -->
+
+    <request name="set_layer" since="2">
+      <description summary="change the layer of the surface">
+        Change the layer that the surface is rendered on.
+
+        Layer is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="layer" type="uint" enum="zwlr_layer_shell_v1.layer" summary="layer to move this surface to"/>
+    </request>
+
+    <!-- Version 5 additions -->
+
+    <request name="set_exclusive_edge" since="5">
+      <description summary="set the edge the exclusive zone will be applied to">
+        Requests an edge for the exclusive zone to apply. The exclusive
+        edge will be automatically deduced from anchor points when possible,
+        but when the surface is anchored to a corner, it will be necessary
+        to set it explicitly to disambiguate, as it is not possible to deduce
+        which one of the two corner edges should be used.
+
+        The edge must be one the surface is anchored to, otherwise the
+        invalid_exclusive_edge protocol error will be raised.
+      </description>
+      <arg name="edge" type="uint" enum="anchor"/>
+    </request>
+  </interface>
+</protocol>


### PR DESCRIPTION
## Problem

wooz currently creates an `xdg_toplevel` and calls `xdg_toplevel_set_fullscreen()` on it. On wlroots-based compositors that enforce a single fullscreen window per output (**niri**, recent **sway**, **hyprland** with `monitor:...,strict_fs`), this request is silently ignored whenever another window is already fullscreen — a game, a browser in F11, mpv on `f`. The result: wooz spawns but becomes invisible / unfocusable, so the zoom keybind effectively does nothing exactly when the user is most likely to want a zoom (during a fullscreen presentation, a game, or a fullscreen video).

## Approach

Replace `xdg_toplevel` + fullscreen with a `zwlr_layer_surface_v1` on the `ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY` layer:

- **Overlay layer** renders *above* `xdg_toplevel` windows, including those in fullscreen state (same as how mako notifications and swaylock work).
- **`keyboard_interactivity: exclusive`** lets wooz steal keyboard focus from the fullscreen app underneath, so `Esc` and arrow-key pan still work.
- **`set_exclusive_zone(-1)`** keeps wooz at the full output size regardless of panels with positive exclusive zones.
- **Anchor all four edges** = fills the output without needing `set_size`.
- **Bind at protocol version 4** (the version where `set_keyboard_interactivity` was added).

This is precisely the pattern swaylock uses, and it sidesteps the fullscreen-slot contention entirely.

## Code Changes

- `main.c` — swap `xdg-shell-protocol.h` include for `wlr-layer-shell-unstable-v1-protocol.h`; remove `xdg_wm_base_ping`, `xdg_surface_configure`, `xdg_toplevel_{configure,close,configure_bounds,wm_capabilities}` and their listener vtables; add `layer_surface_configure` + `layer_surface_closed` handlers. The first-configure initial-zoom logic is preserved verbatim.
- `include/wooz.h` — replace `xdg_wm_base/xdg_toplevel/xdg_surface` struct fields with `zwlr_layer_shell_v1/zwlr_layer_surface_v1`. Drop now-dead per-window state (`is_fullscreen`, `is_maximized`, `is_tiled_*`, `wm_capabilities` sub-struct, `configure` sub-struct) that was only ever populated from `xdg_toplevel_configure`.
- `protocol/meson.build` — vendor `wlr-layer-shell-unstable-v1.xml` (analogous to how `wlr-screencopy-unstable-v1.xml` is already vendored, since neither is in wayland-protocols). The existing `xdg-shell.xml` entry stays — `wlr-layer-shell`'s `get_popup` request references `xdg_popup`, so the generated layer-shell C code needs `xdg_popup_interface` at link time.

Diff summary: \`+40 / -192\` plus the vendored XML (`+417` lines, that's a protocol file).

## Compatibility

- **wlr-based compositors** (sway, niri, hyprland, river, wayfire, labwc): ✅ supported.
- **GNOME/mutter, KDE/kwin**: ❌ don't implement \`wlr-layer-shell\` — but they also don't implement \`wlr-screencopy\`, which wooz needs for its core function, so they were never supported anyway. Net regression: none.

## Test

Tested on **niri 25.05.x** with fullscreen Firefox (`F11`): wooz appears above the fullscreen window, scroll-zoom works, `Esc` and Right-Click close cleanly, the underlying window returns to its previous state without focus loss or state corruption.

Happy to make changes if you'd prefer this gated behind a meson option (\`-Dlayer_shell=true\`) instead of being the default, but my read is that since wooz already requires wlroots compositors via `wlr-screencopy`, making the secondary surface also wlroots-native is consistent with the existing constraint, not a new one.